### PR TITLE
Add workflow to collect Sincera data

### DIFF
--- a/.github/workflows/get-sincera-data.yml
+++ b/.github/workflows/get-sincera-data.yml
@@ -1,0 +1,33 @@
+name: Collect Sincera Data
+
+on:
+  deployment:
+    types: [created]
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  get-data:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+
+      - name: Fetch Sincera ecosystem data
+        env:
+          SINCERA_API_KEY: ${{ secrets.SINCERA_API_KEY }}
+        run: |
+          bash scripts/fetch_sincera_data.sh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: sincera-ecosystem-data
+          path: output/ecosystem_data.json

--- a/scripts/fetch_sincera_data.sh
+++ b/scripts/fetch_sincera_data.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+mkdir -p output
+
+API_URL="${SINCERA_API_URL:-https://api.sincera.io/v1/ecosystem}"
+
+curl -sfSL -H "Authorization: Bearer ${SINCERA_API_KEY}" "$API_URL" -o output/ecosystem_data.json
+
+ls -l output/ecosystem_data.json


### PR DESCRIPTION
## Summary
- add script to fetch Sincera ecosystem data
- add GitHub Actions workflow triggered on deployment to store that data as an artifact

## Testing
- `bash -n scripts/fetch_sincera_data.sh`
- `SINCERA_API_KEY=dummy SINCERA_API_URL=https://example.com bash scripts/fetch_sincera_data.sh`

------
https://chatgpt.com/codex/tasks/task_b_686ec50fade0832ba1b563360f4f6259