### PR TITLE
Add script to fetch Sincera ecosystem data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ecosystem.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
-# getSinceraData
+#getSinceraData
 
-Basically how this is going to work is via a github action. On any deploy it will go and hit up the sincera api and get what it needs, store it as some object and probably format it and put it on s3. Maybe later we'll add some visualization of that object
+This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result as `ecosystem.json`.
+
+## Usage
+
+Ensure that the `SINCERA_API_KEY` environment variable is available (for example via GitHub Actions secrets). Optionally assume the AWS role defined in `AWS_ROLE_TO_ASSUME` before running the script if you need to upload the file to S3.
+
+```bash
+./scripts/fetch_ecosystem.sh
+```

--- a/scripts/fetch_ecosystem.sh
+++ b/scripts/fetch_ecosystem.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_KEY="${SINCERA_API_KEY:-}"
+if [[ -z "$API_KEY" ]]; then
+  echo "SINCERA_API_KEY environment variable is not set" >&2
+  exit 1
+fi
+
+API_URL="https://open.sincera.io/api/ecosystem"
+
+# Fetch the ecosystem data and store in file
+response=$(curl -s -w "%{http_code}" -H "Authorization: Bearer $API_KEY" "$API_URL")
+status="${response: -3}"
+body="${response::-3}"
+
+if [[ "$status" != "200" ]]; then
+  echo "Request failed with status $status" >&2
+  echo "$body" >&2
+  exit 1
+fi
+
+echo "$body" > ecosystem.json
+echo "Data written to ecosystem.json"


### PR DESCRIPTION
## Summary
- add `fetch_ecosystem.sh` that calls the Sincera API using the `SINCERA_API_KEY` secret
- update README with usage instructions
- ignore generated `ecosystem.json`

## Testing
- `SINCERA_API_KEY=dummy ./scripts/fetch_ecosystem.sh`

------
https://chatgpt.com/codex/tasks/task_b_686ec8e43284832b876677cdc0893ed4