### PR TITLE
Fix API endpoint for Sincera data fetch

### DIFF
--- a/scripts/fetch_sincera_data.sh
+++ b/scripts/fetch_sincera_data.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 mkdir -p output
 
-API_URL="${SINCERA_API_URL:-https://api.sincera.io/v1/ecosystem}"
+# Default to the OpenSincera API endpoint documented in the portal
+API_URL="${SINCERA_API_URL:-https://open.sincera.io/api/ecosystem}"
 
 curl -sfSL -H "Authorization: Bearer ${SINCERA_API_KEY}" "$API_URL" -o output/ecosystem_data.json
 


### PR DESCRIPTION
## Summary
- use OpenSincera API URL in `fetch_sincera_data.sh`

## Testing
- `curl -I https://api.sincera.io/v1/ecosystem` *(shows 404)*
- `curl -I https://open.sincera.io/api/ecosystem` *(shows 401 without token)*

------
https://chatgpt.com/codex/tasks/task_b_686ecae1e474832bad18e689feef4db7