### PR TITLE
Upload S3 artifact

### DIFF
--- a/.github/workflows/get-sincera-data.yml
+++ b/.github/workflows/get-sincera-data.yml
@@ -28,8 +28,8 @@ jobs:
         run: |
           bash scripts/fetch_sincera_data.sh
 
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: sincera-ecosystem-data
-          path: output/ecosystem_data.json
+      - name: Upload to S3
+        env:
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+        run: |
+          aws s3 cp output/ecosystem_data.json "s3://${AWS_BUCKET_NAME}/ecosystem_data.json"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 #getSinceraData
 
-This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result as `ecosystem.json`.
+This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result in `output/ecosystem_data.json` and uploads it to an S3 bucket if `AWS_BUCKET_NAME` is set.
 
 ## Usage
 
-Ensure that the `SINCERA_API_KEY` environment variable is available (for example via GitHub Actions secrets). Make sure the AWS role is defined in `AWS_ROLE_TO_ASSUME` before running the script to upload the file to S3 and put the bucket name in `AWS_BUCKET_NAME`.
+Ensure that the `SINCERA_API_KEY` environment variable is available (for example via GitHub Actions secrets). To upload the file to S3 you must also configure the AWS role via `AWS_ROLE_TO_ASSUME` and provide the bucket name in `AWS_BUCKET_NAME`.
 
 ```bash
-./scripts/fetch_ecosystem.sh
+./scripts/fetch_sincera_data.sh
 ```

--- a/scripts/fetch_sincera_data.sh
+++ b/scripts/fetch_sincera_data.sh
@@ -9,3 +9,7 @@ API_URL="${SINCERA_API_URL:-https://open.sincera.io/api/ecosystem}"
 curl -sfSL -H "Authorization: Bearer ${SINCERA_API_KEY}" "$API_URL" -o output/ecosystem_data.json
 
 ls -l output/ecosystem_data.json
+
+if [[ -n "${AWS_BUCKET_NAME:-}" ]]; then
+  aws s3 cp output/ecosystem_data.json "s3://${AWS_BUCKET_NAME}/ecosystem_data.json"
+fi


### PR DESCRIPTION
## Summary
- upload the fetched ecosystem data to S3 instead of GitHub artifact
- document how to use the script
- automatically upload to S3 if the bucket is configured

## Testing
- `bash -n scripts/fetch_sincera_data.sh`

------
https://chatgpt.com/codex/tasks/task_b_686ed40d2220832b803afc5d7628e753