### PR TITLE
Add A2CR sampling script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@ Ensure that the `SINCERA_API_KEY` environment variable is available (for example
 ```bash
 ./scripts/fetch_sincera_data.sh
 ```
+
+### Sampling publisher A2CR
+
+The `sample_a2cr.py` script takes random samples from CafeMedia and
+Mediavine `sellers.json` files, fetches A2CR data for each domain from
+OpenSincera and writes the responses to the `output/` directory.  The
+script requires the `SINCERA_API_KEY` environment variable and Python
+packages `requests` and `numpy`.
+
+```bash
+SINCERA_API_KEY=your_token python scripts/sample_a2cr.py
+```

--- a/scripts/sample_a2cr.py
+++ b/scripts/sample_a2cr.py
@@ -1,0 +1,70 @@
+import os
+import random
+import time
+import json
+import requests
+import numpy as np
+
+CAFEMEDIA_URL = 'https://ads.cafemedia.com/sellers.json'
+MEDIAVINE_URL = 'https://www.mediavine.com/sellers.json'
+API_URL = 'https://open.sincera.io/api/publishers'
+OUTPUT_DIR = 'output'
+
+API_KEY = os.environ.get('SINCERA_API_KEY')
+
+if API_KEY is None:
+    raise SystemExit('SINCERA_API_KEY environment variable is not set')
+
+HEADERS = {'Authorization': f'Bearer {API_KEY}'}
+
+def load_domains(url: str):
+    data = requests.get(url, timeout=30).json()
+    domains = [s.get('domain') for s in data.get('sellers', []) if s.get('domain')]
+    return list(set(domains))
+
+def sample_domains(domains, n=100):
+    if len(domains) < n:
+        n = len(domains)
+    return random.sample(domains, n)
+
+def fetch_a2cr(domain: str):
+    resp = requests.get(API_URL, params={'domain': domain}, headers=HEADERS, timeout=30)
+    if resp.status_code != 200:
+        return None, {'error': resp.text, 'status_code': resp.status_code}
+    data = resp.json()
+    return data.get('avg_ads_to_content_ratio'), data
+
+def process_group(url: str, name: str):
+    domains = load_domains(url)
+    sample = sample_domains(domains)
+    results = {}
+    for d in sample:
+        a2cr, resp = fetch_a2cr(d)
+        results[d] = {'a2cr': a2cr, 'response': resp}
+        time.sleep(1)  # simple throttle
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    with open(os.path.join(OUTPUT_DIR, f'{name}_results.json'), 'w') as f:
+        json.dump(results, f, indent=2)
+    values = [r['a2cr'] for r in results.values() if r['a2cr'] is not None]
+    percentiles = {}
+    if values:
+        percentiles = {
+            'p25': float(np.percentile(values, 25)),
+            'p50': float(np.percentile(values, 50)),
+            'p75': float(np.percentile(values, 75)),
+        }
+    return percentiles
+
+def main():
+    cafe_stats = process_group(CAFEMEDIA_URL, 'cafemedia')
+    mediavine_stats = process_group(MEDIAVINE_URL, 'mediavine')
+    summary = {
+        'cafemedia_percentiles': cafe_stats,
+        'mediavine_percentiles': mediavine_stats,
+    }
+    with open(os.path.join(OUTPUT_DIR, 'summary.json'), 'w') as f:
+        json.dump(summary, f, indent=2)
+    print(json.dumps(summary, indent=2))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- sample 100 domains from CafeMedia and Mediavine `sellers.json`
- query OpenSincera for A2CR and compute percentiles
- document new script in README

## Testing
- `python scripts/sample_a2cr.py` *(fails: `SINCERA_API_KEY` environment variable is not set)*
- `curl -i -H 'Authorization: Bearer dummy' "https://open.sincera.io/api/publishers?domain=businessinsider.com"` *(returns 401 Unauthorized)*

------
https://chatgpt.com/codex/tasks/task_b_686ed6fba430832bbdf5ef7e61cdbb42