### PR TITLE
Fix workflow push permission

### DIFF
--- a/.github/workflows/update_reference_sellers_lists.yml
+++ b/.github/workflows/update_reference_sellers_lists.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   update-sellers:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
## Summary
- allow GitHub Actions to push updates to reference sellers lists

## Testing
- `shellcheck scripts/fetch_sincera_data.sh`
- `python3 -m py_compile scripts/sample_a2cr.py`


------
https://chatgpt.com/codex/tasks/task_b_686eda0820e0832b99f9471957c36517