### PR TITLE
Add freestar and aditude sellers lists

### DIFF
--- a/.github/workflows/update_reference_sellers_lists.yml
+++ b/.github/workflows/update_reference_sellers_lists.yml
@@ -22,6 +22,8 @@ jobs:
           curl -fSL https://ads.shemedia.com/sellers.json -o reference_sellers_lists/sellers_shemedia.json
           curl -fSL https://ads.cafemedia.com/sellers.json -o reference_sellers_lists/sellers_cafemedia.json
           curl -fSL https://www.mediavine.com/sellers.json -o reference_sellers_lists/sellers_mediavine.json
+          curl -fSL https://freestar.com/sellers.json -o reference_sellers_lists/sellers_freestar.json
+          curl -fSL https://www.aditude.com/sellers.json -o reference_sellers_lists/sellers_aditude.json
 
       - name: Commit and push changes
         run: |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ensure that the `SINCERA_API_KEY` environment variable is available (for example
 
 ## Reference sellers lists
 
-On every merge into `main`, a GitHub Actions workflow downloads the latest `sellers.json` files from SheMedia, CafeMedia, and Mediavine. The files are committed to the `reference_sellers_lists/` directory.
+On every merge into `main`, a GitHub Actions workflow downloads the latest `sellers.json` files from SheMedia, CafeMedia, Mediavine, Freestar, and Aditude. The files are committed to the `reference_sellers_lists/` directory.
 
 ### Sampling publisher A2CR
 


### PR DESCRIPTION
## Summary
- update workflow to pull `freestar.com` and `aditude.com` seller lists
- mention new sources in README

## Testing
- `python -m py_compile scripts/sample_a2cr.py`
- `bash -n scripts/fetch_sincera_data.sh`

------
https://chatgpt.com/codex/tasks/task_b_686eda56c59c832b8f5cd8a1840ac1dc