### PR TITLE
Add data_output tracking

### DIFF
--- a/.github/workflows/get-sincera-data.yml
+++ b/.github/workflows/get-sincera-data.yml
@@ -32,4 +32,4 @@ jobs:
         env:
           AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
         run: |
-          aws s3 cp output/ecosystem_data.json "s3://${AWS_BUCKET_NAME}/ecosystem_data.json"
+          aws s3 cp data_output/ecosystem.json "s3://${AWS_BUCKET_NAME}/ecosystem.json"

--- a/.github/workflows/update_reference_sellers_lists.yml
+++ b/.github/workflows/update_reference_sellers_lists.yml
@@ -26,13 +26,26 @@ jobs:
           curl -fSL https://ads.cafemedia.com/sellers.json -o reference_sellers_lists/sellers_cafemedia.json
           curl -fSL https://www.mediavine.com/sellers.json -o reference_sellers_lists/sellers_mediavine.json
 
+      - name: Fetch Sincera ecosystem data
+        env:
+          SINCERA_API_KEY: ${{ secrets.SINCERA_API_KEY }}
+        run: |
+          bash scripts/fetch_sincera_data.sh
+
+      - name: Sample A2CR data
+        env:
+          SINCERA_API_KEY: ${{ secrets.SINCERA_API_KEY }}
+        run: |
+          pip install requests numpy
+          python scripts/sample_a2cr.py
+
       - name: Commit and push changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           if git status --porcelain | grep .; then
-            git add reference_sellers_lists/*.json
-            git commit -m "Update reference sellers lists"
+            git add reference_sellers_lists/*.json data_output/*
+            git commit -m "Update sellers lists and data output"
             git push
           else
             echo "No changes to commit"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-ecosystem.json
+# Previously ignored output

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #getSinceraData
 
-This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result in `output/ecosystem_data.json` and uploads it to an S3 bucket if `AWS_BUCKET_NAME` is set.
+This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result in `data_output/ecosystem.json` and uploads it to an S3 bucket if `AWS_BUCKET_NAME` is set.
 
 ## Usage
 
@@ -12,13 +12,13 @@ Ensure that the `SINCERA_API_KEY` environment variable is available (for example
 
 ## Reference sellers lists
 
-On every merge into `main`, a GitHub Actions workflow downloads the latest `sellers.json` files from SheMedia, CafeMedia, and Mediavine. The files are committed to the `reference_sellers_lists/` directory.
+On every merge into `main`, a GitHub Actions workflow downloads the latest `sellers.json` files from SheMedia, CafeMedia, and Mediavine. The files are committed to the `reference_sellers_lists/` directory. The workflow also refreshes the ecosystem metadata and A2CR samples and commits them to the `data_output/` directory.
 
 ### Sampling publisher A2CR
 
 The `sample_a2cr.py` script takes random samples from CafeMedia and
 Mediavine `sellers.json` files, fetches A2CR data for each domain from
-OpenSincera and writes the responses to the `output/` directory.  The
+OpenSincera and writes the responses to the `data_output/` directory.  The
 script requires the `SINCERA_API_KEY` environment variable and Python
 packages `requests` and `numpy`.
 

--- a/scripts/fetch_sincera_data.sh
+++ b/scripts/fetch_sincera_data.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
-mkdir -p output
+mkdir -p data_output
 
 # Default to the OpenSincera API endpoint documented in the portal
 API_URL="${SINCERA_API_URL:-https://open.sincera.io/api/ecosystem}"
 
-curl -sfSL -H "Authorization: Bearer ${SINCERA_API_KEY}" "$API_URL" -o output/ecosystem_data.json
+curl -sfSL -H "Authorization: Bearer ${SINCERA_API_KEY}" "$API_URL" -o data_output/ecosystem.json
 
-ls -l output/ecosystem_data.json
+ls -l data_output/ecosystem.json
 
 if [[ -n "${AWS_BUCKET_NAME:-}" ]]; then
-  aws s3 cp output/ecosystem_data.json "s3://${AWS_BUCKET_NAME}/ecosystem_data.json"
+  aws s3 cp data_output/ecosystem.json "s3://${AWS_BUCKET_NAME}/ecosystem.json"
 fi

--- a/scripts/sample_a2cr.py
+++ b/scripts/sample_a2cr.py
@@ -8,7 +8,7 @@ import numpy as np
 CAFEMEDIA_URL = 'https://ads.cafemedia.com/sellers.json'
 MEDIAVINE_URL = 'https://www.mediavine.com/sellers.json'
 API_URL = 'https://open.sincera.io/api/publishers'
-OUTPUT_DIR = 'output'
+OUTPUT_DIR = 'data_output'
 
 API_KEY = os.environ.get('SINCERA_API_KEY')
 


### PR DESCRIPTION
## Summary
- store data into `data_output` directory
- update S3 workflow to use new path
- extend merge workflow to fetch ecosystem and sample A2CR data
- document new behavior in README

## Testing
- `python -m py_compile scripts/sample_a2cr.py`
- `bash -n scripts/fetch_sincera_data.sh`
- `shellcheck` not available

------
https://chatgpt.com/codex/tasks/task_b_686edaf133e0832b96a59b87d8ed5876