### PR TITLE
Use local sellers lists for sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ On every merge into `main`, a GitHub Actions workflow downloads the latest `sell
 
 ### Sampling publisher A2CR
 
-The `sample_a2cr.py` script takes random samples from CafeMedia and
-Mediavine `sellers.json` files, fetches A2CR data for each domain from
+The `sample_a2cr.py` script reads the CafeMedia and Mediavine
+`sellers.json` files stored in `reference_sellers_lists`, takes random
+samples from those domains, fetches A2CR data for each domain from
 OpenSincera and writes the responses to the `output/` directory.  The
 script requires the `SINCERA_API_KEY` environment variable and Python
 packages `requests` and `numpy`.

--- a/scripts/sample_a2cr.py
+++ b/scripts/sample_a2cr.py
@@ -5,8 +5,9 @@ import json
 import requests
 import numpy as np
 
-CAFEMEDIA_URL = 'https://ads.cafemedia.com/sellers.json'
-MEDIAVINE_URL = 'https://www.mediavine.com/sellers.json'
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CAFEMEDIA_FILE = os.path.join(BASE_DIR, 'reference_sellers_lists', 'sellers_cafemedia.json')
+MEDIAVINE_FILE = os.path.join(BASE_DIR, 'reference_sellers_lists', 'sellers_mediavine.json')
 API_URL = 'https://open.sincera.io/api/publishers'
 OUTPUT_DIR = 'output'
 
@@ -17,8 +18,9 @@ if API_KEY is None:
 
 HEADERS = {'Authorization': f'Bearer {API_KEY}'}
 
-def load_domains(url: str):
-    data = requests.get(url, timeout=30).json()
+def load_domains(path: str):
+    with open(path, 'r') as f:
+        data = json.load(f)
     domains = [s.get('domain') for s in data.get('sellers', []) if s.get('domain')]
     return list(set(domains))
 
@@ -34,8 +36,8 @@ def fetch_a2cr(domain: str):
     data = resp.json()
     return data.get('avg_ads_to_content_ratio'), data
 
-def process_group(url: str, name: str):
-    domains = load_domains(url)
+def process_group(path: str, name: str):
+    domains = load_domains(path)
     sample = sample_domains(domains)
     results = {}
     for d in sample:
@@ -56,8 +58,8 @@ def process_group(url: str, name: str):
     return percentiles
 
 def main():
-    cafe_stats = process_group(CAFEMEDIA_URL, 'cafemedia')
-    mediavine_stats = process_group(MEDIAVINE_URL, 'mediavine')
+    cafe_stats = process_group(CAFEMEDIA_FILE, 'cafemedia')
+    mediavine_stats = process_group(MEDIAVINE_FILE, 'mediavine')
     summary = {
         'cafemedia_percentiles': cafe_stats,
         'mediavine_percentiles': mediavine_stats,


### PR DESCRIPTION
## Summary
- read `reference_sellers_lists` in `sample_a2cr.py` instead of downloading sellers.json files
- document that the sampling script uses the local sellers lists

## Testing
- `python -m py_compile scripts/sample_a2cr.py`

------
https://chatgpt.com/codex/tasks/task_b_686edb3d0aec832b9104434564d0f71a