### PR TITLE
Upload Sincera outputs to separate S3 folders

### DIFF
--- a/.github/workflows/get-sincera-data.yml
+++ b/.github/workflows/get-sincera-data.yml
@@ -32,4 +32,4 @@ jobs:
         env:
           AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
         run: |
-          aws s3 cp data_output/ecosystem.json "s3://${AWS_BUCKET_NAME}/ecosystem.json"
+          aws s3 cp data_output/ecosystem.json "s3://${AWS_BUCKET_NAME}/ecosystem/ecosystem.json"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # getSinceraData
 
-This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result in `data_output/ecosystem.json` and uploads it to an S3 bucket if `AWS_BUCKET_NAME` is set.
+This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result in `data_output/ecosystem.json` and uploads it to an S3 bucket if `AWS_BUCKET_NAME` is set. The file is uploaded under the `ecosystem/` prefix within the bucket.
 
 ## Usage
 
@@ -18,9 +18,11 @@ On every merge into `main`, a GitHub Actions workflow downloads the latest `sell
 The `sample_a2cr.py` script reads the CafeMedia and Mediavine
 `sellers.json` files stored in `reference_sellers_lists`, takes random
 samples from those domains, fetches A2CR data for each domain from
-OpenSincera and writes the responses to the `output/` directory.  The
+OpenSincera and writes the responses to the `data_output/` directory. The
 script requires the `SINCERA_API_KEY` environment variable and Python
-packages `requests` and `numpy`.
+packages `requests` and `numpy`. When `AWS_BUCKET_NAME` is set, the raw files
+are uploaded to `a2cr_raw/` in the bucket and the summary is uploaded to
+`a2cr_results/`.
 
 ```bash
 SINCERA_API_KEY=your_token python scripts/sample_a2cr.py

--- a/scripts/fetch_sincera_data.sh
+++ b/scripts/fetch_sincera_data.sh
@@ -11,5 +11,5 @@ curl -sfSL -H "Authorization: Bearer ${SINCERA_API_KEY}" "$API_URL" -o data_outp
 ls -l data_output/ecosystem.json
 
 if [[ -n "${AWS_BUCKET_NAME:-}" ]]; then
-  aws s3 cp data_output/ecosystem.json "s3://${AWS_BUCKET_NAME}/ecosystem.json"
+  aws s3 cp data_output/ecosystem.json "s3://${AWS_BUCKET_NAME}/ecosystem/ecosystem.json"
 fi

--- a/scripts/sample_a2cr.py
+++ b/scripts/sample_a2cr.py
@@ -2,6 +2,7 @@ import os
 import random
 import time
 import json
+import subprocess
 import requests
 import numpy as np
 
@@ -10,6 +11,7 @@ CAFEMEDIA_FILE = os.path.join(BASE_DIR, 'reference_sellers_lists', 'sellers_cafe
 MEDIAVINE_FILE = os.path.join(BASE_DIR, 'reference_sellers_lists', 'sellers_mediavine.json')
 API_URL = 'https://open.sincera.io/api/publishers'
 OUTPUT_DIR = 'data_output'
+AWS_BUCKET_NAME = os.environ.get('AWS_BUCKET_NAME')
 
 API_KEY = os.environ.get('SINCERA_API_KEY')
 
@@ -17,6 +19,16 @@ if API_KEY is None:
     raise SystemExit('SINCERA_API_KEY environment variable is not set')
 
 HEADERS = {'Authorization': f'Bearer {API_KEY}'}
+
+
+def upload_to_s3(local_path: str, key: str) -> None:
+    """Upload a file to S3 if AWS_BUCKET_NAME is set."""
+    if not AWS_BUCKET_NAME:
+        return
+    subprocess.run(
+        ["aws", "s3", "cp", local_path, f"s3://{AWS_BUCKET_NAME}/{key}"],
+        check=True,
+    )
 
 def load_domains(path: str):
     with open(path, 'r') as f:
@@ -45,8 +57,10 @@ def process_group(path: str, name: str):
         results[d] = {'a2cr': a2cr, 'response': resp}
         time.sleep(1)  # simple throttle
     os.makedirs(OUTPUT_DIR, exist_ok=True)
-    with open(os.path.join(OUTPUT_DIR, f'{name}_results.json'), 'w') as f:
+    result_file = os.path.join(OUTPUT_DIR, f'{name}_results.json')
+    with open(result_file, 'w') as f:
         json.dump(results, f, indent=2)
+    upload_to_s3(result_file, f'a2cr_raw/{name}_results.json')
     values = [r['a2cr'] for r in results.values() if r['a2cr'] is not None]
     percentiles = {}
     if values:
@@ -64,8 +78,10 @@ def main():
         'cafemedia_percentiles': cafe_stats,
         'mediavine_percentiles': mediavine_stats,
     }
-    with open(os.path.join(OUTPUT_DIR, 'summary.json'), 'w') as f:
+    summary_file = os.path.join(OUTPUT_DIR, 'summary.json')
+    with open(summary_file, 'w') as f:
         json.dump(summary, f, indent=2)
+    upload_to_s3(summary_file, 'a2cr_results/summary.json')
     print(json.dumps(summary, indent=2))
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- upload fetched ecosystem data under an `ecosystem/` prefix
- add helper to sample script to upload raw results to `a2cr_raw/` and summary to `a2cr_results/`
- update GitHub Actions workflow for new path
- document the S3 folder structure in README

## Testing
- `bash -n scripts/fetch_sincera_data.sh`
- `python -m py_compile scripts/sample_a2cr.py`


------
https://chatgpt.com/codex/tasks/task_b_686edd866a34832baf11188c798263f7