### PR TITLE
Fix jsonlint not found error

### DIFF
--- a/scripts/fetch_sincera_data.sh
+++ b/scripts/fetch_sincera_data.sh
@@ -8,7 +8,9 @@ API_URL="${SINCERA_API_URL:-https://open.sincera.io/api/ecosystem}"
 
 curl -sfSL -H "Authorization: Bearer ${SINCERA_API_KEY}" "$API_URL" -o ecosystem/ecosystem.json
 
-jsonlint -p -i data_output/ecosystem.json
+# Validate and pretty-print the JSON without requiring the jsonlint package
+python3 -m json.tool ecosystem/ecosystem.json \
+  > ecosystem/ecosystem.json.tmp && mv ecosystem/ecosystem.json.tmp ecosystem/ecosystem.json
 
 ls -l ecosystem/ecosystem.json
 


### PR DESCRIPTION
## Summary
- replace jsonlint with built-in json.tool for pretty-printing

## Testing
- `bash -n scripts/fetch_sincera_data.sh`
- `SINCERA_API_KEY=fakekey SINCERA_API_URL=file://$PWD/dummy.json bash scripts/fetch_sincera_data.sh`

------
https://chatgpt.com/codex/tasks/task_b_686ee0843714832b9d1476fa917bc88d