### PR TITLE
Redo PR #18 on latest main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # getSinceraData
 
-This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result in `ecosystem/ecosystem.json` and uploads it to an S3 bucket if `AWS_BUCKET_NAME` is set.
+This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result in `ecosystem/ecosystem.json` and uploads it to an S3 bucket if `AWS_BUCKET_NAME` is set. The file is uploaded under the `ecosystem/` prefix within the bucket.
 
 ## Usage
 
@@ -22,6 +22,9 @@ The `sample_a2cr.py` script reads every `sellers.json` file stored in
   written to `ac2r_analysis/`. The
   script requires the `SINCERA_API_KEY` environment variable and Python
 packages `requests` and `numpy`.
+  When `AWS_BUCKET_NAME` is set, the raw files are uploaded to
+  `raw_ac2r/` in the bucket and the summary is uploaded to
+  `ac2r_analysis/`.
 
 ```bash
 SINCERA_API_KEY=your_token python scripts/sample_a2cr.py

--- a/scripts/sample_a2cr.py
+++ b/scripts/sample_a2cr.py
@@ -2,6 +2,7 @@ import os
 import random
 import time
 import json
+import subprocess
 import requests
 import numpy as np
 
@@ -17,6 +18,7 @@ def list_sellers_files():
 API_URL = 'https://open.sincera.io/api/publishers'
 RAW_OUTPUT_DIR = 'raw_ac2r'
 ANALYSIS_DIR = 'ac2r_analysis'
+AWS_BUCKET_NAME = os.environ.get('AWS_BUCKET_NAME')
 
 API_KEY = os.environ.get('SINCERA_API_KEY')
 
@@ -24,6 +26,16 @@ if API_KEY is None:
     raise SystemExit('SINCERA_API_KEY environment variable is not set')
 
 HEADERS = {'Authorization': f'Bearer {API_KEY}'}
+
+
+def upload_to_s3(local_path: str, key: str) -> None:
+    """Upload a file to S3 if AWS_BUCKET_NAME is set."""
+    if not AWS_BUCKET_NAME:
+        return
+    subprocess.run(
+        ["aws", "s3", "cp", local_path, f"s3://{AWS_BUCKET_NAME}/{key}"],
+        check=True,
+    )
 
 def load_domains(path: str):
     with open(path, 'r') as f:
@@ -59,8 +71,10 @@ def process_group(path: str, name: str):
         results[d] = {'a2cr': a2cr, 'response': resp}
         time.sleep(2)  # throttle requests to avoid rate limits
     os.makedirs(RAW_OUTPUT_DIR, exist_ok=True)
-    with open(os.path.join(RAW_OUTPUT_DIR, f'{name}_results.json'), 'w') as f:
+    result_file = os.path.join(RAW_OUTPUT_DIR, f'{name}_results.json')
+    with open(result_file, 'w') as f:
         json.dump(results, f, indent=2)
+    upload_to_s3(result_file, f'raw_ac2r/{name}_results.json')
     values = [r['a2cr'] for r in results.values() if r['a2cr'] is not None]
     percentiles = {}
     if values:
@@ -79,8 +93,10 @@ def main():
         summary[f'{name}_percentiles'] = stats
 
     os.makedirs(ANALYSIS_DIR, exist_ok=True)
-    with open(os.path.join(ANALYSIS_DIR, 'summary.json'), 'w') as f:
+    summary_file = os.path.join(ANALYSIS_DIR, 'summary.json')
+    with open(summary_file, 'w') as f:
         json.dump(summary, f, indent=2)
+    upload_to_s3(summary_file, 'ac2r_analysis/summary.json')
 
     print(json.dumps(summary, indent=2))
 


### PR DESCRIPTION
## Summary
- support uploading A2CR results to S3
- document the S3 locations for ecosystem and A2CR outputs

## Testing
- `python -m py_compile scripts/sample_a2cr.py`
- `pip install requests numpy` *(ran to satisfy dependencies)*
- `SINCERA_API_KEY=dummy python scripts/sample_a2cr.py` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_b_686edfefb8e4832b9b2439ef76e61b60