### PR TITLE
Add S3 upload support to a2cr script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # getSinceraData
 
-This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result in `output/ecosystem/ecosystem.json` and uploads it to an S3 bucket if `AWS_BUCKET_NAME` is set.
+This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result in `output/ecosystem/ecosystem.json` and uploads it to an S3 bucket if `AWS_BUCKET_NAME` is set. The file is uploaded under the `ecosystem/` prefix within the bucket.
 
 ## Usage
 
@@ -22,6 +22,9 @@ The `sample_a2cr.py` script reads every `sellers.json` file stored in
   written to `output/ac2r_analysis/`. The
   script requires the `SINCERA_API_KEY` environment variable and Python
 packages `requests` and `numpy`.
+  When `AWS_BUCKET_NAME` is set, the raw files are uploaded to
+  `raw_ac2r/` in the bucket and the summary is uploaded to
+  `ac2r_analysis/`.
 
 ```bash
 SINCERA_API_KEY=your_token python scripts/sample_a2cr.py


### PR DESCRIPTION
## Summary
- note that ecosystem JSON uploads under the `ecosystem/` prefix
- document upload locations for `sample_a2cr.py`
- add optional S3 uploads to `sample_a2cr.py`

## Testing
- `python -m py_compile scripts/sample_a2cr.py`


------
https://chatgpt.com/codex/tasks/task_b_686ee25135d0832ba7201d04b03cb5fc