### PR TITLE
Ensure output directory is synced to S3

### DIFF
--- a/.github/workflows/get-sincera-data.yml
+++ b/.github/workflows/get-sincera-data.yml
@@ -28,8 +28,3 @@ jobs:
         run: |
           bash scripts/fetch_sincera_data.sh
 
-      - name: Upload to S3
-        env:
-          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
-        run: |
-          aws s3 cp output/ecosystem/ecosystem.json "s3://${AWS_BUCKET_NAME}/ecosystem/ecosystem.json"

--- a/.github/workflows/update_reference_sellers_lists.yml
+++ b/.github/workflows/update_reference_sellers_lists.yml
@@ -19,6 +19,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+
       - name: Fetch sellers.json files
         run: |
           mkdir -p reference_sellers_lists
@@ -31,12 +37,14 @@ jobs:
       - name: Fetch Sincera ecosystem data
         env:
           SINCERA_API_KEY: ${{ secrets.SINCERA_API_KEY }}
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
         run: |
           bash scripts/fetch_sincera_data.sh
 
       - name: Sample A2CR data
         env:
           SINCERA_API_KEY: ${{ secrets.SINCERA_API_KEY }}
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
         run: |
           pip install requests numpy
           python scripts/sample_a2cr.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # getSinceraData
 
-This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result in `output/ecosystem/ecosystem.json` and uploads it to an S3 bucket if `AWS_BUCKET_NAME` is set. The file is uploaded under the `ecosystem/` prefix within the bucket.
+This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result in `output/ecosystem/ecosystem.json`.
+If `AWS_BUCKET_NAME` is set, the entire `output/` directory is synced to the same folder structure in the bucket using `scripts/sync_output_to_s3.sh`.
 
 ## Usage
 
@@ -22,8 +23,8 @@ The `sample_a2cr.py` script reads every `sellers.json` file stored in
   written to `output/ac2r_analysis/`. The
   script requires the `SINCERA_API_KEY` environment variable and Python
 packages `requests` and `numpy`.
-  When `AWS_BUCKET_NAME` is set, the raw files are uploaded to
-  `raw_ac2r/` in the bucket and the summary is uploaded to
+  When `AWS_BUCKET_NAME` is set, the entire `output/` directory is synced to the bucket
+  using `scripts/sync_output_to_s3.sh` so the files appear under `raw_ac2r/` and
   `ac2r_analysis/`.
 
 ```bash

--- a/scripts/fetch_sincera_data.sh
+++ b/scripts/fetch_sincera_data.sh
@@ -15,5 +15,5 @@ python3 -m json.tool output/ecosystem/ecosystem.json \
 ls -l output/ecosystem/ecosystem.json
 
 if [[ -n "${AWS_BUCKET_NAME:-}" ]]; then
-  aws s3 cp output/ecosystem/ecosystem.json "s3://${AWS_BUCKET_NAME}/ecosystem/ecosystem.json"
+  bash "$(dirname "$0")/sync_output_to_s3.sh"
 fi

--- a/scripts/sample_a2cr.py
+++ b/scripts/sample_a2cr.py
@@ -28,11 +28,12 @@ if API_KEY is None:
 HEADERS = {'Authorization': f'Bearer {API_KEY}'}
 
 
-def upload_to_s3(local_path: str, key: str) -> None:
-    """Upload a file to S3 if AWS_BUCKET_NAME is set."""
+def sync_output() -> None:
+    """Sync the entire output directory to S3 if AWS_BUCKET_NAME is set."""
     if not AWS_BUCKET_NAME:
         return
-    subprocess.run(["aws", "s3", "cp", local_path, f"s3://{AWS_BUCKET_NAME}/{key}"], check=True)
+    script = os.path.join(os.path.dirname(__file__), 'sync_output_to_s3.sh')
+    subprocess.run(["bash", script], check=True)
 
 def load_domains(path: str):
     with open(path, 'r') as f:
@@ -73,7 +74,7 @@ def process_group(path: str, name: str):
     result_file = os.path.join(RAW_OUTPUT_DIR, f'{name}_results.json')
     with open(result_file, 'w') as f:
         json.dump(results, f, indent=2)
-    upload_to_s3(result_file, f'raw_ac2r/{name}_results.json')
+    # sync will handle uploading this file if AWS_BUCKET_NAME is set
     values = [r['a2cr'] for r in results.values() if r['a2cr'] is not None]
     percentiles = {}
     if values:
@@ -95,7 +96,7 @@ def main():
     summary_file = os.path.join(ANALYSIS_DIR, 'summary.json')
     with open(summary_file, 'w') as f:
         json.dump(summary, f, indent=2)
-    upload_to_s3(summary_file, 'ac2r_analysis/summary.json')
+    sync_output()
 
     print(json.dumps(summary, indent=2))
 

--- a/scripts/sync_output_to_s3.sh
+++ b/scripts/sync_output_to_s3.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ -z "${AWS_BUCKET_NAME:-}" ]]; then
+  echo "AWS_BUCKET_NAME not set; skipping S3 upload" >&2
+  exit 0
+fi
+
+aws s3 sync output/ "s3://${AWS_BUCKET_NAME}/"


### PR DESCRIPTION
## Summary
- add script to sync the entire `output/` directory to S3
- call sync script from `fetch_sincera_data.sh` and `sample_a2cr.py`
- update README with S3 sync details
- update workflows to configure AWS credentials and rely on the sync script

## Testing
- `bash scripts/sync_output_to_s3.sh` *(prints AWS_BUCKET_NAME not set)*
- `AWS_BUCKET_NAME=bucket SINCERA_API_KEY=fake bash scripts/fetch_sincera_data.sh` *(fails with 401 due to fake key)*
- `AWS_BUCKET_NAME=bucket SINCERA_API_KEY=key python scripts/sample_a2cr.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_686ee4f39824832b83690f1f537d0266