### PR TITLE
Fix AWS credentials step

### DIFF
--- a/.github/workflows/update_reference_sellers_lists.yml
+++ b/.github/workflows/update_reference_sellers_lists.yml
@@ -7,6 +7,7 @@ on:
       - main
 
 permissions:
+  id-token: write
   contents: write
 
 jobs:


### PR DESCRIPTION
## Summary
- add `id-token: write` permission so that aws-actions can assume the role via OIDC

## Testing
- `python -m py_compile scripts/sample_a2cr.py`


------
https://chatgpt.com/codex/tasks/task_b_686ee6f69380832bbb5ccd5149e64190