### PR TITLE
Fix duplicate permission entry

### DIFF
--- a/.github/workflows/update_reference_sellers_lists.yml
+++ b/.github/workflows/update_reference_sellers_lists.yml
@@ -9,7 +9,6 @@ on:
 permissions:
   id-token: write
   contents: write
-  id-token: write
 
 jobs:
   update-sellers:


### PR DESCRIPTION
## Summary
- fix a duplicated `id-token` permission in the update_reference_sellers_lists workflow

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_686ee969b9d4832ba7613fd0ac58a8e5