### PR TITLE
Run workflow on push

### DIFF
--- a/.github/workflows/update_reference_sellers_lists.yml
+++ b/.github/workflows/update_reference_sellers_lists.yml
@@ -1,8 +1,7 @@
 name: Update Data on Merge
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - main
 
@@ -12,7 +11,6 @@ permissions:
 
 jobs:
   update-sellers:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- trigger workflow on push to `main`

## Testing
- `bash -n scripts/fetch_sincera_data.sh`
- `bash -n scripts/sync_output_to_s3.sh`
- `python3 -m py_compile scripts/sample_a2cr.py`


------
https://chatgpt.com/codex/tasks/task_b_686eea7d973c832bbf5e6f0cd678fc09