### PR TITLE
Add sample size to A2CR summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ The `sample_a2cr.py` script reads every `sellers.json` file stored in
 `reference_sellers_lists`, takes random samples from the domains listed,
   fetches A2CR data for each domain from OpenSincera and writes the
   raw results to the `output/raw_ac2r/` directory. The summary statistics are
-  written to `output/ac2r_analysis/`. The
+  written to `output/ac2r_analysis/`. Each entry in the summary includes the
+  number of domains used to calculate the percentiles.
+  The
   script requires the `SINCERA_API_KEY` environment variable and Python
 packages `requests` and `numpy`.
   When `AWS_BUCKET_NAME` is set, the entire `output/` directory is synced to the bucket

--- a/scripts/sample_a2cr.py
+++ b/scripts/sample_a2cr.py
@@ -85,13 +85,17 @@ def process_group(path: str, name: str):
         json.dump(results, f, indent=2)
     # sync will handle uploading this file if AWS_BUCKET_NAME is set
     values = [r['a2cr'] for r in results.values() if r['a2cr'] is not None]
-    percentiles = {}
+    percentiles = {
+        'n': len(values),
+    }
     if values:
-        percentiles = {
-            'p25': float(np.percentile(values, 25)),
-            'p50': float(np.percentile(values, 50)),
-            'p75': float(np.percentile(values, 75)),
-        }
+        percentiles.update(
+            {
+                'p25': float(np.percentile(values, 25)),
+                'p50': float(np.percentile(values, 50)),
+                'p75': float(np.percentile(values, 75)),
+            }
+        )
     return percentiles
 
 def main():


### PR DESCRIPTION
## Summary
- modify `sample_a2cr.py` to include number of values used when calculating percentiles
- document the new `n` field in README

## Testing
- `pip install requests numpy`
- `SINCERA_API_KEY=fake SAMPLE_SIZE=1 python scripts/sample_a2cr.py`

------
https://chatgpt.com/codex/tasks/task_b_686ee9e73710832bbb809faf7ac13386