### PR TITLE
Skip S3 sync if AWS secrets missing

### DIFF
--- a/.github/workflows/update_reference_sellers_lists.yml
+++ b/.github/workflows/update_reference_sellers_lists.yml
@@ -21,6 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Configure AWS credentials
+        if: ${{ secrets.AWS_ROLE_TO_ASSUME != '' && secrets.AWS_BUCKET_NAME != '' }}
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
@@ -53,6 +54,7 @@ jobs:
         env:
           SINCERA_API_KEY: ${{ secrets.SINCERA_API_KEY }}
           AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         run: |
           bash scripts/fetch_sincera_data.sh
 
@@ -74,6 +76,7 @@ jobs:
         env:
           SINCERA_API_KEY: ${{ secrets.SINCERA_API_KEY }}
           AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         run: |
           pip install requests numpy
           python scripts/sample_a2cr.py

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # getSinceraData
 
 This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result in `output/ecosystem/ecosystem.json`.
-If `AWS_BUCKET_NAME` is set, the entire `output/` directory is synced to the same folder structure in the bucket using `scripts/sync_output_to_s3.sh`.
+If both `AWS_BUCKET_NAME` and `AWS_ROLE_TO_ASSUME` are set, the entire `output/` directory is synced to the same folder structure in the bucket using `scripts/sync_output_to_s3.sh`.
 
 ## Usage
 
@@ -33,7 +33,7 @@ The `sample_a2cr.py` script reads every `sellers.json` file stored in
   The
   script requires the `SINCERA_API_KEY` environment variable and Python
 packages `requests` and `numpy`.
-  When `AWS_BUCKET_NAME` is set, the entire `output/` directory is synced to the bucket
+  When both `AWS_BUCKET_NAME` and `AWS_ROLE_TO_ASSUME` are set, the entire `output/` directory is synced to the bucket
   using `scripts/sync_output_to_s3.sh` so the files appear under `raw_ac2r/` and
   `ac2r_analysis/`.
 

--- a/scripts/fetch_sincera_data.sh
+++ b/scripts/fetch_sincera_data.sh
@@ -14,6 +14,6 @@ python3 -m json.tool output/ecosystem/ecosystem.json \
 
 ls -l output/ecosystem/ecosystem.json
 
-if [[ -n "${AWS_BUCKET_NAME:-}" ]]; then
+if [[ -n "${AWS_BUCKET_NAME:-}" && -n "${AWS_ROLE_TO_ASSUME:-}" ]]; then
   bash "$(dirname "$0")/sync_output_to_s3.sh"
 fi

--- a/scripts/sample_a2cr.py
+++ b/scripts/sample_a2cr.py
@@ -19,6 +19,7 @@ API_URL = 'https://open.sincera.io/api/publishers'
 RAW_OUTPUT_DIR = os.path.join('output', 'raw_ac2r')
 ANALYSIS_DIR = os.path.join('output', 'ac2r_analysis')
 AWS_BUCKET_NAME = os.environ.get('AWS_BUCKET_NAME')
+AWS_ROLE_TO_ASSUME = os.environ.get('AWS_ROLE_TO_ASSUME')
 
 API_KEY = os.environ.get('SINCERA_API_KEY')
 
@@ -29,8 +30,8 @@ HEADERS = {'Authorization': f'Bearer {API_KEY}'}
 
 
 def sync_output() -> None:
-    """Sync the entire output directory to S3 if AWS_BUCKET_NAME is set."""
-    if not AWS_BUCKET_NAME:
+    """Sync the entire output directory to S3 if bucket and role are set."""
+    if not AWS_BUCKET_NAME or not AWS_ROLE_TO_ASSUME:
         return
     script = os.path.join(os.path.dirname(__file__), 'sync_output_to_s3.sh')
     subprocess.run(["bash", script], check=True)


### PR DESCRIPTION
## Summary
- skip AWS credential configuration if bucket and role secrets are undefined
- require both bucket and role to sync outputs to S3
- document that both secrets are needed for S3 upload

## Testing
- `python -m py_compile scripts/sample_a2cr.py`
- `bash -n scripts/fetch_sincera_data.sh`
- `bash -n scripts/sync_output_to_s3.sh`


------
https://chatgpt.com/codex/tasks/task_b_686efd10ff90832bb313027d7f70b85f