### PR TITLE
Add additional percentile metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The `sample_a2cr.py` script reads every `sellers.json` file stored in
   raw results to the `output/raw_ac2r/` directory. The summary statistics are
   written to `output/ac2r_analysis/`. Each entry in the summary includes the
   number of domains used to calculate the percentiles.
+  In addition to A2CR, the summary contains percentile data for
+  `total_supply_paths` and `avg_page_weight`.
   The
   script requires the `SINCERA_API_KEY` environment variable and Python
 packages `requests` and `numpy`.


### PR DESCRIPTION
## Summary
- extend `sample_a2cr.py` percentile calculation to include `total_supply_paths` and `avg_page_weight`
- mention new metrics in README

## Testing
- `python -m py_compile scripts/sample_a2cr.py`

------
https://chatgpt.com/codex/tasks/task_b_686f03fcb1bc832b8f42677c7c5d8f86