### PR TITLE
Add Playwire sellers list

### DIFF
--- a/.github/workflows/update_reference_sellers_lists.yml
+++ b/.github/workflows/update_reference_sellers_lists.yml
@@ -34,6 +34,7 @@ jobs:
           curl -fSL https://www.mediavine.com/sellers.json -o reference_sellers_lists/sellers_mediavine.json
           curl -fSL https://freestar.com/sellers.json -o reference_sellers_lists/sellers_freestar.json
           curl -fSL https://www.aditude.com/sellers.json -o reference_sellers_lists/sellers_aditude.json
+          curl -fSL https://config.playwire.com/sellers.json -o reference_sellers_lists/sellers_playwire.json
 
       - name: Commit sellers lists
         run: |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ensure that the `SINCERA_API_KEY` environment variable is available (for example
 ```
 
 ## Reference sellers lists
-When the `trigger_data_pull.txt` file changes on `main`, a GitHub Actions workflow downloads the latest `sellers.json` files from SheMedia, CafeMedia, Mediavine, Freestar, and Aditude. The files are committed to the `reference_sellers_lists/` directory.
+When the `trigger_data_pull.txt` file changes on `main`, a GitHub Actions workflow downloads the latest `sellers.json` files from SheMedia, CafeMedia, Mediavine, Freestar, Aditude, and Playwire. The files are committed to the `reference_sellers_lists/` directory.
 
 To trigger the data pull, edit `trigger_data_pull.txt` and change the value after `last_pull =` to a new date or version, for example:
 


### PR DESCRIPTION
## Summary
- update README to mention Playwire
- fetch Playwire's sellers.json in the workflow

## Testing
- `python -m py_compile scripts/sample_a2cr.py`
- `bash -n scripts/fetch_sincera_data.sh`

------
https://chatgpt.com/codex/tasks/task_b_686f1546c694832b874dfe59784968da