### PR TITLE
Enhance streamlit viz with combined percentile plot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit
 pandas
+altair

--- a/streamlit_app/streamlit_app.py
+++ b/streamlit_app/streamlit_app.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pandas as pd
 import streamlit as st
+import altair as alt
 
 DATA_FILE = Path(__file__).resolve().parents[1] / "output" / "ac2r_analysis" / "summary.json"
 
@@ -14,16 +15,50 @@ def load_data():
 def main() -> None:
     st.title("A2CR Summary")
     data = load_data()
+
+    rows = []
     for seller, stats in data.items():
-        st.subheader(seller.replace("_", " ").title())
-        st.metric("Number of domains", stats["n"])
-        df = pd.DataFrame(
-            {
-                "percentile": ["p25", "p50", "p75"],
-                "value": [stats["p25"], stats["p50"], stats["p75"],],
-            }
-        ).set_index("percentile")
-        st.bar_chart(df)
+        network = (
+            seller.replace("sellers_", "")
+            .replace("_percentiles", "")
+            .replace("_", " ")
+            .title()
+        )
+        rows.append({
+            "network": network,
+            "n": stats["n"],
+            "p25": stats["p25"],
+            "p50": stats["p50"],
+            "p75": stats["p75"],
+        })
+
+    df = pd.DataFrame(rows)
+
+    base = alt.Chart(df).encode(x=alt.X("network:N", title="Network"))
+    rule = base.mark_rule().encode(y="p25:Q", y2="p75:Q")
+
+    long_df = df.melt(
+        id_vars=["network"],
+        value_vars=["p25", "p50", "p75"],
+        var_name="percentile",
+        value_name="value",
+    )
+
+    points = (
+        alt.Chart(long_df)
+        .mark_point(filled=True, size=100)
+        .encode(
+            x="network:N",
+            y=alt.Y("value:Q", title="A2CR"),
+            color="percentile:N",
+            shape="percentile:N",
+        )
+    )
+
+    st.altair_chart(rule + points, use_container_width=True)
+
+    st.subheader("Number of domains used for each network")
+    st.table(df.set_index("network")["n"])
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- visualize all networks on one chart using Altair
- display a whisker-style rule from p25 to p75 with percentile points
- list the number of domains for each network
- require `altair` for plotting

## Testing
- `python -m py_compile streamlit_app/streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_b_686f18aff7ac832b93efce3113bf9b10