### PR TITLE
Implement API rate limit handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The `sample_a2cr.py` script reads every `sellers.json` file stored in
   The
   script requires the `SINCERA_API_KEY` environment variable and Python
 packages `requests` and `numpy`.
+  The script automatically respects the OpenSincera API's rate limits of
+  45 requests per rolling minute and 5000 requests per day.
   When both `AWS_BUCKET_NAME` and `AWS_ROLE_TO_ASSUME` are set, the entire `output/` directory is synced to the bucket
   using `scripts/sync_output_to_s3.sh` so the files appear under `raw_ac2r/` and
   `ac2r_analysis/`.


### PR DESCRIPTION
## Summary
- add a rate limiter to `sample_a2cr.py`
- throttle looped requests to 1s
- document API rate limit handling in README

## Testing
- `python3 -m py_compile scripts/sample_a2cr.py`

------
https://chatgpt.com/codex/tasks/task_b_686f89444a88832b821bd9b34d9d0482