### PR TITLE
Fix expired AWS token

### DIFF
--- a/.github/workflows/update_reference_sellers_lists.yml
+++ b/.github/workflows/update_reference_sellers_lists.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: us-east-1
+          role-duration-seconds: 14400
 
       - name: Fetch sellers.json files
         run: |


### PR DESCRIPTION
## Summary
- extend AWS credential duration to prevent mid-run expirations

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_686f936263d0832bb5b8f276d7d771b6