### PR TITLE
Fix AWS credential timeout during A2CR job

### DIFF
--- a/.github/workflows/update_reference_sellers_lists.yml
+++ b/.github/workflows/update_reference_sellers_lists.yml
@@ -94,3 +94,15 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Refresh AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: us-east-1
+
+      - name: Sync output to S3
+        env:
+          AWS_BUCKET_NAME: ${{ secrets.AWS_BUCKET_NAME }}
+        run: |
+          bash scripts/sync_output_to_s3.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # getSinceraData
 
 This repository contains a simple script to fetch the Sincera ecosystem data. The API key is provided via the `SINCERA_API_KEY` GitHub secret. When run, the script stores the result in `output/ecosystem/ecosystem.json`.
-If both `AWS_BUCKET_NAME` and `AWS_ROLE_TO_ASSUME` are set, the entire `output/` directory is synced to the same folder structure in the bucket using `scripts/sync_output_to_s3.sh`.
+When AWS credentials are available, the GitHub Actions workflow uploads the entire `output/` directory to the configured bucket using `scripts/sync_output_to_s3.sh`.
 
 ## Usage
 
@@ -38,9 +38,9 @@ The `sample_a2cr.py` script reads every `sellers.json` file stored in
   The
   script requires the `SINCERA_API_KEY` environment variable and Python
 packages `requests` and `numpy`.
-  When both `AWS_BUCKET_NAME` and `AWS_ROLE_TO_ASSUME` are set, the entire `output/` directory is synced to the bucket
-  using `scripts/sync_output_to_s3.sh` so the files appear under `raw_ac2r/` and
-  `ac2r_analysis/`.
+  When both `AWS_BUCKET_NAME` and `AWS_ROLE_TO_ASSUME` are set, the workflow runs
+  `scripts/sync_output_to_s3.sh` so the files appear under `raw_ac2r/` and
+  `ac2r_analysis/` in the bucket.
 
 ```bash
 SINCERA_API_KEY=your_token SAMPLE_SIZE=5 python scripts/sample_a2cr.py

--- a/scripts/fetch_sincera_data.sh
+++ b/scripts/fetch_sincera_data.sh
@@ -14,6 +14,3 @@ python3 -m json.tool output/ecosystem/ecosystem.json \
 
 ls -l output/ecosystem/ecosystem.json
 
-if [[ -n "${AWS_BUCKET_NAME:-}" && -n "${AWS_ROLE_TO_ASSUME:-}" ]]; then
-  bash "$(dirname "$0")/sync_output_to_s3.sh"
-fi

--- a/scripts/sample_a2cr.py
+++ b/scripts/sample_a2cr.py
@@ -128,7 +128,7 @@ def main():
     summary_file = os.path.join(ANALYSIS_DIR, 'summary.json')
     with open(summary_file, 'w') as f:
         json.dump(summary, f, indent=2)
-    sync_output()
+
 
     print(json.dumps(summary, indent=2))
 


### PR DESCRIPTION
## Summary
- ensure a fresh AWS session before running the S3 sync
- sync output using its own workflow step

## Testing
- `python -m py_compile scripts/sample_a2cr.py`
- `bash -n scripts/fetch_sincera_data.sh`
- `bash -n scripts/sync_output_to_s3.sh`


------
https://chatgpt.com/codex/tasks/task_b_686f8e58aa80832b9b9e838503dbd9c7