### PR TITLE
Add coverage and CI workflow

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+branch = True
+source =
+    scripts
+    streamlit_app
+
+[report]
+exclude_lines =
+    if __name__ == "__main__":

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,24 @@
+name: Python Tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest pytest-cov
+      - name: Run tests
+        run: pytest --cov=scripts --cov=streamlit_app

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 # Previously ignored output
+.coverage


### PR DESCRIPTION
## Summary
- ignore Python coverage file
- add a .coveragerc config
- run pytest with coverage in GitHub Actions on pushes to `main` and pull requests

## Testing
- `pytest --cov=scripts --cov=streamlit_app -q`

------
https://chatgpt.com/codex/tasks/task_b_686f9ca03070832bbde9f319bcc03405