### PR TITLE
Remove redundant AWS credential step

### DIFF
--- a/.github/workflows/update_reference_sellers_lists.yml
+++ b/.github/workflows/update_reference_sellers_lists.yml
@@ -20,12 +20,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          aws-region: us-east-1
-
       - name: Fetch sellers.json files
         run: |
           mkdir -p reference_sellers_lists
@@ -95,7 +89,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Refresh AWS credentials
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
## Summary
- clean up workflow that updates the data
- only configure AWS credentials once right before the S3 sync

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686fb9cfefd4832ba46f13ee20039a36