### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Ensure that the `SINCERA_API_KEY` environment variable is available (for example
 ```
 ## Visualization
 
-The github action deploys data back to this repo, which https://getsinceradata.streamlit.app/ points at.
+The GitHub Action deploys data back to this repo, which https://getsinceradata.streamlit.app/ points at.
 
 ## Reference sellers lists
 When the `trigger_data_pull.txt` file changes on `main`, a GitHub Actions workflow downloads the latest `sellers.json` files from SheMedia, CafeMedia, Mediavine, Freestar, Aditude, and Playwire. The files are committed to the `reference_sellers_lists/` directory.


### PR DESCRIPTION
## Summary
- correct GitHub Action capitalization in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68713b095c04832bae8521a545551d67